### PR TITLE
Apply `--no-early-exit` flag to the existing subcommand

### DIFF
--- a/lib/command/src/build_runner/build_runner_command.ts
+++ b/lib/command/src/build_runner/build_runner_command.ts
@@ -1,4 +1,8 @@
 import { cliffy } from 'deps.ts'
+import {
+  addEarlyExitOptions,
+  EarlyExitOptions,
+} from '../common/early_exit_options.ts'
 
 const subcommands: { readonly [command: string]: string } = {
   b: 'build',
@@ -21,13 +25,15 @@ function subcommandType(
   return subcommands[value]
 }
 
+export type BuildRunnerOptions = EarlyExitOptions
+
 /**
  * `build_runner` subcommand.
  *
  * `br` is one of the aliases for `build_runner`.
  */
 export function buildRunnerCommand() {
-  return new cliffy.command.Command()
+  const command = new cliffy.command.Command()
     .usage('[OPTIONS] <subcommand> [args...]')
     .alias('br')
     .description(
@@ -37,6 +43,6 @@ export function buildRunnerCommand() {
         `"build/b", "clean/c", "run/r"`,
     )
     .type('subcommand', subcommandType)
-    .stopEarly()
     .arguments('<subcommand:subcommand> [args...:string]')
+  return addEarlyExitOptions(command).stopEarly()
 }

--- a/lib/command/src/build_runner/build_runner_command_runner.ts
+++ b/lib/command/src/build_runner/build_runner_command_runner.ts
@@ -2,12 +2,14 @@ import { Traversal } from 'concurrency/mod.ts'
 import { Context } from 'context/mod.ts'
 import { DError } from 'error/mod.ts'
 import { Workspace } from 'workspace/mod.ts'
+import { BuildRunnerOptions } from './build_runner_command.ts'
 
 export async function runBuildRunnerCommand(
   context: Context,
-  { args, rawArgs }: {
+  { args, rawArgs, options }: {
     args: string[]
     rawArgs: string[]
+    options: BuildRunnerOptions
   },
 ): Promise<void> {
   const workspace = await Workspace.fromContext(context, {
@@ -26,7 +28,7 @@ export async function runBuildRunnerCommand(
       context,
       command: 'dart',
       args: ['run', 'build_runner', ...args],
-      earlyExit: false,
+      earlyExit: options.earlyExit,
     })
   } catch (error) {
     throw new DError(

--- a/lib/command/src/common/early_exit_options.ts
+++ b/lib/command/src/common/early_exit_options.ts
@@ -1,0 +1,57 @@
+// deno-lint-ignore-file no-explicit-any
+
+import { cliffy } from 'deps.ts'
+
+export type EarlyExitOptions = {
+  readonly earlyExit: boolean
+}
+
+/**
+ * Adds early exit options to the given {@link command}.
+ */
+export function addEarlyExitOptions<
+  TParentCommandGlobals extends Record<string, unknown> | void = void,
+  TParentCommandTypes extends Record<string, unknown> | void =
+    TParentCommandGlobals extends number ? any : void,
+  TCommandOptions extends Record<string, unknown> | void =
+    TParentCommandGlobals extends number ? any : void,
+  TCommandArguments extends Array<unknown> = TParentCommandGlobals extends
+    number ? any : [],
+  TCommandGlobals extends Record<string, unknown> | void =
+    TParentCommandGlobals extends number ? any : void,
+  TCommandTypes extends Record<string, unknown> | void =
+    TParentCommandGlobals extends number ? any : {
+      number: number
+      integer: number
+      string: string
+      boolean: boolean
+      file: string
+    },
+  TCommandGlobalTypes extends Record<string, unknown> | void =
+    TParentCommandGlobals extends number ? any : void,
+  TParentCommand extends cliffy.command.Command<any> | undefined =
+    TParentCommandGlobals extends number ? any : undefined,
+>(
+  command: cliffy.command.Command<
+    TParentCommandGlobals,
+    TParentCommandTypes,
+    TCommandOptions,
+    TCommandArguments,
+    TCommandGlobals,
+    TCommandTypes,
+    TCommandGlobalTypes,
+    TParentCommand
+  >,
+) {
+  return command
+    .option(
+      '--early-exit',
+      'Exit as soon as possible when any failure happens on any package',
+      { default: true },
+    )
+    .option(
+      '--no-early-exit',
+      'Execute the command for all packages even though a failure happens on ' +
+        'any package',
+    )
+}

--- a/lib/command/src/pub/pub_command.ts
+++ b/lib/command/src/pub/pub_command.ts
@@ -1,10 +1,14 @@
 import { cliffy } from 'deps.ts'
 import {
+  addEarlyExitOptions,
+  EarlyExitOptions,
+} from '../common/early_exit_options.ts'
+import {
   addPackageFilterOptions,
   PackageFilterOptions,
 } from '../common/package_filter_options.ts'
 
-export type PubOptions = PackageFilterOptions
+export type PubOptions = PackageFilterOptions & EarlyExitOptions
 
 /**
  * `pub` subcommand.
@@ -14,5 +18,5 @@ export function pubCommand() {
     .description('Commands for managing Flutter packages.')
     .usage(`[OPTIONS] <pub-subcommand> [pub-args]`)
     .arguments(`<subcommand> [args...]`)
-  return addPackageFilterOptions(command).stopEarly()
+  return addEarlyExitOptions(addPackageFilterOptions(command)).stopEarly()
 }

--- a/lib/command/src/pub/pub_command_runner.ts
+++ b/lib/command/src/pub/pub_command_runner.ts
@@ -35,6 +35,7 @@ export async function runPubCommand(
       context,
       command: 'flutter',
       args: ['pub', ...args],
+      earlyExit: options.earlyExit,
     })
   } catch (error) {
     throw new DError(`Failed to run \`pub\` command with result: ${error}`)

--- a/lib/options/src/options.ts
+++ b/lib/options/src/options.ts
@@ -1,5 +1,6 @@
 import {
   BootstrapOptions,
+  BuildRunnerOptions,
   CleanOptions,
   PubOptions,
   UpdateOptions,
@@ -41,7 +42,7 @@ export type Flags =
     }
     | {
       readonly name: 'build_runner'
-      readonly options: GlobalOptions
+      readonly options: BuildRunnerOptions & GlobalOptions
     }
   )
 


### PR DESCRIPTION
Applies `--no-early-exit` flag to `pub` and `build_runner` subcommands.